### PR TITLE
Generate temp dir in os.tempdir()

### DIFF
--- a/src/commands/generateProject.ts
+++ b/src/commands/generateProject.ts
@@ -43,7 +43,11 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
     const packageName = getPackageName(targetDirectory.fsPath);
 
     // make a tmp directory in the target folder to generate files into
-    tmpDirPath = await fileUtil.generateTempDirectory(targetDirectory.fsPath);
+    tmpDirPath = await fileUtil.generateTempDirectory();
+    if (tmpDirPath === undefined) {
+      console.error("Failed to generate a temporary directory.");
+      return;
+    }
 
     // if they are using a URL download the file to the temp directory
     if (inputYamlMethod === INPUT_YAML_OPTIONS.FROM_URL) {
@@ -99,7 +103,9 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
     );
   } catch (e) {
     console.error(e);
-    vscode.window.showErrorMessage("Failed to generate MicroProfile rest client");
+    vscode.window.showErrorMessage(
+      "Failed to generate MicroProfile Rest Client interface template."
+    );
   } finally {
     // remove the tmp directory after if it exists
     if (tmpDirPath !== undefined && (await fileUtil.exists(tmpDirPath))) {

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -5,6 +5,7 @@ import { promisify } from "util";
 import * as path from "path";
 import * as ncp from "ncp";
 import * as fsExtra from "fs-extra";
+import * as os from "os";
 
 interface DownloadRequestOptions {
   url: string;
@@ -35,22 +36,18 @@ export async function downloadFile(
 
 export const exists = promisify(fs.exists);
 
-const _mkdir = promisify(fs.mkdir);
-export async function mkdir(dir: string): Promise<void> {
+const _mkdtemp = promisify(fs.mkdtemp);
+export async function mkdtemp(dir: string): Promise<string | undefined> {
   if (!(await exists(dir))) {
-    await _mkdir(dir);
+    return await _mkdtemp(dir);
   }
 }
 
 // generates a temp directory in a existing dir and returns the name of the tmp dir
-export async function generateTempDirectory(dir: string): Promise<string> {
-  const randomSuffix = Math.random()
-    .toString(36)
-    .substr(2, 5);
-  const tempDirName = `tmp-${randomSuffix}`;
-  const fullTempDirPath = path.join(dir, tempDirName);
-  await mkdir(fullTempDirPath);
-  return fullTempDirPath;
+export async function generateTempDirectory(): Promise<string | undefined> {
+  const tmpDirPrefix = "vscode-rest-client-generator-";
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), tmpDirPrefix));
+  return tmpDir;
 }
 
 export const copy = promisify(ncp);


### PR DESCRIPTION
Fix for temp directory bug.
- Use `fs.mkdtemp` function, if unable to call this function, return undefined and log error.
- Generate temp directory at `os.tempdir()`

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>