### PR TITLE
Add option to generate without OpenAPI specification validation

### DIFF
--- a/src/commands/generateProject.ts
+++ b/src/commands/generateProject.ts
@@ -9,6 +9,7 @@ import { getWorkspaceFolderIfExists, getPackageName, generateRestClient } from "
 export async function generateProject(clickedFileUri: vscode.Uri | undefined): Promise<void> {
   // extension uses a tmp directory to download / generate files into
   let tmpDirPath: string | undefined;
+  let yamlType: string | undefined;
 
   // default URI to use when presenting the user a file picker
   // ie. when asking for yaml file or target folder to generate rest client into
@@ -22,8 +23,10 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
 
     if (inputYamlMethod === INPUT_YAML_OPTIONS.FROM_FILE) {
       yamlInputFileURI = await prompts.askForYamlFile(defaultFilePickerURI);
+      yamlType = "file";
     } else if (inputYamlMethod === INPUT_YAML_OPTIONS.FROM_URL) {
       yamlInputURL = await prompts.askForYamlURL();
+      yamlType = "url";
     }
 
     // if neither an input file or input URL are specified exit the generator
@@ -95,8 +98,8 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
       await generateRestClient(jarCommand);
     } catch (e) {
       if (e.message.includes(SPEC_VALIDATION_EXCEPTION)) {
-        const selection = await vscode.window.showInformationMessage(
-          "The yaml file provided failed the OpenAPI Generator specification validation. Would you like to generate without specification validation?",
+        const selection = await vscode.window.showErrorMessage(
+          `The provided yaml ${yamlType} failed the OpenAPI specification validation. Would you like to generate without specification validation?`,
           ...["Yes", "No"]
         );
         if (selection === "Yes") {

--- a/src/commands/generateProject.ts
+++ b/src/commands/generateProject.ts
@@ -1,10 +1,10 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as prompts from "../util/vscodePrompts";
-import { INPUT_YAML_OPTIONS, GENERATOR_JAR_PATH } from "../constants";
+import { INPUT_YAML_OPTIONS, GENERATOR_JAR_PATH, SPEC_VALIDATION_EXCEPTION } from "../constants";
 import * as fileUtil from "../util/file";
 import * as processUtil from "../util/process";
-import { getWorkspaceFolder } from "../util/workspace";
+import { getWorkspaceFolderIfExists, getPackageName, generateRestClient } from "../util/workspace";
 
 export async function generateProject(clickedFileUri: vscode.Uri | undefined): Promise<void> {
   // extension uses a tmp directory to download / generate files into
@@ -78,7 +78,7 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
     const modelPackageName = packageName !== "" ? `${packageName}.models` : "models";
 
     // execute generator in temp dir
-    const jarCommand =
+    let jarCommand =
       "java -jar " +
       GENERATOR_JAR_PATH +
       " generate " +
@@ -91,14 +91,22 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
       apiPackageName +
       " --model-package " +
       modelPackageName;
-    // run the generator command with a "progress" dialog
-    await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: "Generating the MicroProfile Rest Client interface template...",
-      },
-      () => processUtil.exec(jarCommand)
-    );
+    try {
+      await generateRestClient(jarCommand);
+    } catch (e) {
+      if (e.message.includes(SPEC_VALIDATION_EXCEPTION)) {
+        const selection = await vscode.window.showInformationMessage(
+          "The yaml file provided failed the OpenAPI Generator specification validation. Would you like to generate without specification validation?",
+          ...["Yes", "No"]
+        );
+        if (selection === "Yes") {
+          jarCommand += " --skip-validate-spec";
+          await generateRestClient(jarCommand);
+        } else {
+          return;
+        }
+      }
+    }
 
     const packagePath = packageName.replace(/\./g, path.sep);
     const generatedRestClientPath = path.resolve(tmpDirPath, "src", "main", "java", packagePath);

--- a/src/commands/generateProject.ts
+++ b/src/commands/generateProject.ts
@@ -3,8 +3,7 @@ import * as path from "path";
 import * as prompts from "../util/vscodePrompts";
 import { INPUT_YAML_OPTIONS, GENERATOR_JAR_PATH, SPEC_VALIDATION_EXCEPTION } from "../constants";
 import * as fileUtil from "../util/file";
-import * as processUtil from "../util/process";
-import { getWorkspaceFolderIfExists, getPackageName, generateRestClient } from "../util/workspace";
+import { getWorkspaceFolder, generateRestClient } from "../util/workspace";
 
 export async function generateProject(clickedFileUri: vscode.Uri | undefined): Promise<void> {
   // extension uses a tmp directory to download / generate files into

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,5 @@ export const GENERATOR_JAR_PATH = path.join(
   __dirname,
   "../node_modules/@openapitools/openapi-generator-cli/bin/openapi-generator.jar"
 );
+
+export const SPEC_VALIDATION_EXCEPTION = "SpecValidationException";

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import * as processUtil from "../util/process";
 
 /**
  * Gets the first open workspace folder
@@ -26,4 +27,14 @@ export function getDefaultPackageName(targetDir: string): string {
     defaultPackageName = targetDir.substring(index).replace(new RegExp("\\" + path.sep, "g"), ".");
   }
   return defaultPackageName;
+}
+
+export async function generateRestClient(jarCommand: string): Promise<void> {
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "Generating the MicroProfile Rest Client interface template...",
+    },
+    () => processUtil.exec(jarCommand)
+  );
 }


### PR DESCRIPTION
If the initial generation fails and "SpecValidationException" is in the error message, prompt the user to generate again but with the `--skip-validate-spec` flag.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>