### PR TITLE
improve error message when jar generation fails

### DIFF
--- a/src/commands/generateProject.ts
+++ b/src/commands/generateProject.ts
@@ -124,6 +124,7 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
         vscode.window.showErrorMessage(
           "Failed to generate MicroProfile Rest Client interface template."
         );
+        return;
       }
     }
 

--- a/src/commands/generateProject.ts
+++ b/src/commands/generateProject.ts
@@ -97,9 +97,7 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
       await generateRestClient(jarCommand);
     } catch (e) {
       console.error(e);
-      if (!e.message.includes(jarCommand)) {
-        return; // show generic error message
-      } else {
+      if (e.message.includes(jarCommand)) {
         // get error description returned from executing jar command
         let err = e.message.trim().split(jarCommand);
         err = err[1].trim().split("\n")[0];
@@ -122,6 +120,10 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
           );
           return;
         }
+      } else {
+        vscode.window.showErrorMessage(
+          "Failed to generate MicroProfile Rest Client interface template."
+        );
       }
     }
 

--- a/src/commands/generateProject.ts
+++ b/src/commands/generateProject.ts
@@ -96,7 +96,13 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
     try {
       await generateRestClient(jarCommand);
     } catch (e) {
-      if (e.message.includes(SPEC_VALIDATION_EXCEPTION)) {
+      console.error(e);
+      // get error description returned from executing jar command
+      let err = e.message.trim().split(jarCommand);
+      err = err[1].trim().split("\n")[0];
+
+      // catch spec validation error
+      if (err.includes(SPEC_VALIDATION_EXCEPTION)) {
         const selection = await vscode.window.showErrorMessage(
           `The provided yaml ${yamlType} failed the OpenAPI specification validation. Would you like to generate without specification validation?`,
           ...["Yes", "No"]
@@ -107,6 +113,11 @@ export async function generateProject(clickedFileUri: vscode.Uri | undefined): P
         } else {
           return;
         }
+      } else {
+        vscode.window.showErrorMessage(
+          `Failed to generate a MicroProfile Rest Client interface from the provided yaml ${yamlType}: ${err}`
+        );
+        return;
       }
     }
 


### PR DESCRIPTION
Improving the error message for jar generation by displaying the first line of the error message returned from the jar command.  Tested on Mac and Windows. 

![image (1)](https://user-images.githubusercontent.com/26146482/74698132-d068e380-51ca-11ea-95ed-e693397b0785.png)
<img width="375" alt="Screen Shot 2020-02-17 at 9 16 12 PM" src="https://user-images.githubusercontent.com/26146482/74698133-d363d400-51ca-11ea-94b4-d49f3079de2c.png">

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>