### PR TITLE
rename ext to Generator for MicroProfile Rest Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
-All notable changes to the MicroProfile REST Client Generator extension will be documented below.
+All notable changes to the Generator for MicroProfile Rest Client extension will be documented below.
+
+## 0.1.2
+- Rename to Generator for MicroProfile Rest Client
+- Update node-fetch dependency version
 
 ## 0.1.1
 - Add support for all OpenAPI documents (yaml and JSON)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# VS Code MicroProfile Rest Client Generator Extension
+# Generator for MicroProfile Rest Client VS Code Extension
 
 [![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/MicroProfile-Community.mp-rest-client-generator-vscode-ext.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-rest-client-generator-vscode-ext)
 [![Build Status](https://travis-ci.org/MicroShed/mp-starter-vscode-ext.svg?branch=master)](https://travis-ci.org/MicroShed/mp-rest-client-generator-vscode-ext)
 
-The MicroProfile REST Client Generator Extension provides support for generating a [MicroProfile](https://microprofile.io/) REST Client interface template from an [OpenAPI](https://github.com/OAI/OpenAPI-Specification) document. This extension calls the [openapi-generator](https://github.com/OpenAPITools/openapi-generator) to generate `models` and `apis` folders. The code for this extension is hosted under the MicroShed organization on GitHub. Learn more about MicroProfile REST Client on [GitHub](https://github.com/eclipse/microprofile-rest-client).
+The Generator for MicroProfile Rest Client extension provides support for generating a [MicroProfile](https://microprofile.io/) REST Client interface template from an [OpenAPI](https://github.com/OAI/OpenAPI-Specification) document. This extension calls the [openapi-generator](https://github.com/OpenAPITools/openapi-generator) to generate `models` and `apis` folders. The code for this extension is hosted under the MicroShed organization on GitHub. Learn more about MicroProfile Rest Client on [GitHub](https://github.com/eclipse/microprofile-rest-client).
 
 ![Open Liberty Tools Extension](images/RestClientExtension.png)
 
@@ -24,7 +24,7 @@ The extension will generate `models` and `apis` folders into the specified direc
 
 ## Contributing
 
-Contributions to the MicroProfile REST Client Generator extension are welcome!
+Contributions to the Generator for MicroProfile Rest Client extension are welcome!
 
 Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pull requests.
 
@@ -44,3 +44,5 @@ To build and run the extension locally:
 ## Issues
 
 Please report bugs, issues and feature requests by creating a [GitHub issue](https://github.com/MicroShed/mp-rest-client-generator-vscode-ext/issues).
+
+MicroProfile&reg; and the MicroProfile logo are trademarks of the Eclipse Foundation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mp-rest-client-generator-vscode-ext",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mp-rest-client-generator-vscode-ext",
-  "displayName": "MicroProfile REST Client Generator",
+  "displayName": "Generator for MicroProfile Rest Client",
   "description": "Generate a Java MicroProfile REST Client using the OpenAPI Generator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "MicroProfile-Community",
   "license": "EPL-2.0",
   "preview": true,


### PR DESCRIPTION
Rename extension to "Generator for MicroProfile Rest Client" and bump version to `0.1.2`

Fixes #37 
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>