### PR TITLE
fix Windows path with space char

### DIFF
--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -69,7 +69,7 @@ function javaExist(javaPath: string | undefined) : string | undefined {
     let java = path.join(javaPath, "bin");
     java = path.join(java, JAVA_FILENAME);
     if (fs.existsSync(java)) {
-      return java;
+      return '"' + java + '"';
     }
   }
   return undefined;


### PR DESCRIPTION
got following error:
![Screenshot 2024-05-16 at 1 35 27 PM](https://github.com/MicroShed/mp-rest-client-generator-vscode-ext/assets/29576299/de8cd239-120f-48c6-9ef4-207265437719)
